### PR TITLE
fix misnamed configuration option

### DIFF
--- a/src/widget.c
+++ b/src/widget.c
@@ -66,7 +66,7 @@ K_MSGQ_DEFINE(led_msgq, sizeof(struct blink_item), 16, 1);
 
 #if IS_ENABLED(CONFIG_ZMK_BLE)
 void indicate_connectivity(void) {
-    struct blink_item blink = {.duration_ms = CONFIG_RGBLED_WIDGET_OUTPUT_BLINK_MS};
+    struct blink_item blink = {.duration_ms = CONFIG_RGBLED_WIDGET_CONN_BLINK_MS};
 
 #if !IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
     uint8_t profile_index = zmk_ble_active_profile_index();


### PR DESCRIPTION
The README says this should be named with CONN rather than OUTPUT.