### PR TITLE
Show a per-layer configurable color while a layer is active 

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,5 +1,5 @@
 # Color definitions to use with color settings
-COLOR_BLACK   := 0  # no blink
+COLOR_BLACK   := 0
 COLOR_RED     := 1
 COLOR_GREEN   := 2
 COLOR_YELLOW  := 3

--- a/Kconfig
+++ b/Kconfig
@@ -99,6 +99,170 @@ config RGBLED_WIDGET_LAYER_DEBOUNCE_MS
     int "Wait duration after a layer change before showing the highest active layer"
     default 100
 
+# Constant layer color settings
+config RGBLED_WIDGET_SHOW_LAYER_COLORS
+    bool "Use custom colors for layers"
+
+config RGBLED_WIDGET_LAYER_0_COLOR
+    int "Color to use for the base layer"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_1_COLOR
+    int "Color to use for layer 1"
+    range 0 7
+    default $(COLOR_RED)
+
+config RGBLED_WIDGET_LAYER_2_COLOR
+    int "Color to use for layer 2"
+    range 0 7
+    default $(COLOR_GREEN)
+
+config RGBLED_WIDGET_LAYER_3_COLOR
+    int "Color to use for layer 3"
+    range 0 7
+    default $(COLOR_YELLOW)
+
+config RGBLED_WIDGET_LAYER_4_COLOR
+    int "Color to use for layer 4"
+    range 0 7
+    default $(COLOR_BLUE)
+
+config RGBLED_WIDGET_LAYER_5_COLOR
+    int "Color to use for layer 5"
+    range 0 7
+    default $(COLOR_MAGENTA)
+
+config RGBLED_WIDGET_LAYER_6_COLOR
+    int "Color to use for layer 6"
+    range 0 7
+    default $(COLOR_CYAN)
+
+config RGBLED_WIDGET_LAYER_7_COLOR
+    int "Color to use for layer 7"
+    range 0 7
+    default $(COLOR_WHITE)
+
+config RGBLED_WIDGET_LAYER_8_COLOR
+    int "Color to use for layer 8"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_9_COLOR
+    int "Color to use for layer 9"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_10_COLOR
+    int "Color to use for layer 10"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_11_COLOR
+    int "Color to use for layer 11"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_12_COLOR
+    int "Color to use for layer 12"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_13_COLOR
+    int "Color to use for layer 13"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_14_COLOR
+    int "Color to use for layer 14"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_15_COLOR
+    int "Color to use for layer 15"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_16_COLOR
+    int "Color to use for layer 16"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_17_COLOR
+    int "Color to use for layer 17"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_18_COLOR
+    int "Color to use for layer 18"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_19_COLOR
+    int "Color to use for layer 19"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_20_COLOR
+    int "Color to use for layer 20"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_21_COLOR
+    int "Color to use for layer 21"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_22_COLOR
+    int "Color to use for layer 22"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_23_COLOR
+    int "Color to use for layer 23"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_24_COLOR
+    int "Color to use for layer 24"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_25_COLOR
+    int "Color to use for layer 25"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_26_COLOR
+    int "Color to use for layer 26"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_27_COLOR
+    int "Color to use for layer 27"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_28_COLOR
+    int "Color to use for layer 28"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_29_COLOR
+    int "Color to use for layer 29"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_30_COLOR
+    int "Color to use for layer 30"
+    range 0 7
+    default $(COLOR_BLACK)
+
+config RGBLED_WIDGET_LAYER_31_COLOR
+    int "Color to use for layer 31"
+    range 0 7
+    default $(COLOR_BLACK)
+
 endif # RGBLED_WIDGET
 
 DT_COMPAT_ZMK_BEHAVIOR_RGBLED_WIDGET := zmk,behavior-rgbled-widget

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently the widget does the following:
 - Blink 🔵 for connected, 🟡 for open (advertising), 🔴 for disconnected profiles on every BT profile switch (on central side for splits)
 - Blink 🔵 for connected, 🔴 for disconnected on peripheral side of splits
 
-In addition, there are two ways, each off by default, to indicate the layer:
+In addition, there are two ways (each off by default) to indicate the layer:
 
 - enable `CONFIG_RGBLED_WIDGET_SHOW_LAYER_CHANGE` to show the highest active layer on every layer activation
   using a sequence of N cyan color blinks, where N is the zero-based index of the layer.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is used to indicate battery level and BLE connection status in a minimalist w
 <details>
   <summary>Short video demo</summary>
   See below video for a short demo, running through power on, profile switching and power offs.
-  
+
   https://github.com/caksoylar/zmk-rgbled-widget/assets/7876996/cfd89dd1-ff24-4a33-8563-2fdad2a828d4
 </details>
 
@@ -19,8 +19,11 @@ Currently the widget does the following:
 - Blink 🔵 for connected, 🟡 for open (advertising), 🔴 for disconnected profiles on every BT profile switch (on central side for splits)
 - Blink 🔵 for connected, 🔴 for disconnected on peripheral side of splits
 
-If you enable `CONFIG_RGBLED_WIDGET_SHOW_LAYER_CHANGE`, the LED will show the highest active layer on every layer activation
-using a sequence of N cyan color blinks, where N is the zero-based index of the layer.
+In addition, there are two ways, each off by default, to indicate the layer:
+
+- enable `CONFIG_RGBLED_WIDGET_SHOW_LAYER_CHANGE` to show the highest active layer on every layer activation
+  using a sequence of N cyan color blinks, where N is the zero-based index of the layer.
+- enable `CONFIG_RGBLED_WIDGET_SHOW_LAYER_COLORS` to assign each layer its own color, which will remain on while that layer is active.
 
 In addition, there are keymap behaviors you can use to show the status on demand, see [below](#showing-status-on-demand).
 
@@ -49,7 +52,7 @@ manifest:
 
 For more information, including instructions for building locally, check out the ZMK docs on [building with modules](https://zmk.dev/docs/features/modules#building-with-modules).
 
-Then, if you are using one of the boards supported by the [`rgbled_adapter`](/boards/shields/rgbled_adapter) shield such as Xiao BLE,
+Then, if you are using one of the boards supported by the [`rgbled_adapter`](boards/shields/rgbled_adapter) shield such as Xiao BLE,
 just add the `rgbled_adapter` as an additional shield to your build, e.g. in `build.yaml`:
 
 ```yaml build.yaml
@@ -95,25 +98,35 @@ This will happen on all keyboard parts for split keyboards, so make sure to flas
 <details>
 <summary>Expand to see available configuration options</summary>
 
-| Name                                           | Description                                                                  | Default      |
-| ---------------------------------------------- | ---------------------------------------------------------------------------- | ------------ |
-| `CONFIG_RGBLED_WIDGET_INTERVAL_MS`             | Minimum wait duration between two blinks in ms                               | 500          |
-| `CONFIG_RGBLED_WIDGET_BATTERY_BLINK_MS`        | Duration of battery level blink in ms                                        | 2000         |
-| `CONFIG_RGBLED_WIDGET_BATTERY_LEVEL_HIGH`      | High battery level percentage                                                | 80           |
-| `CONFIG_RGBLED_WIDGET_BATTERY_LEVEL_LOW`       | Low battery level percentage                                                 | 20           |
-| `CONFIG_RGBLED_WIDGET_BATTERY_LEVEL_CRITICAL`  | Critical battery level percentage, blink periodically if under               | 5            |
-| `CONFIG_RGBLED_WIDGET_BATTERY_COLOR_HIGH`      | Color for high battery level (above `LEVEL_HIGH`)                            | Green (`2`)  |
-| `CONFIG_RGBLED_WIDGET_BATTERY_COLOR_MEDIUM`    | Color for medium battery level (between `LEVEL_LOW` and `LEVEL_HIGH`)        | Yellow (`3`) |
-| `CONFIG_RGBLED_WIDGET_BATTERY_COLOR_LOW`       | Color for low battery level (below `LEVEL_LOW`)                              | Red (`1`)    |
-| `CONFIG_RGBLED_WIDGET_BATTERY_COLOR_CRITICAL`  | Color for critical battery level (below `LEVEL_CRITICAL`)                    | Red (`1`)    |
-| `CONFIG_RGBLED_WIDGET_CONN_BLINK_MS`           | Duration of BLE connection status blink in ms                                | 1000         |
-| `CONFIG_RGBLED_WIDGET_CONN_COLOR_CONNECTED`    | Color for connected BLE connection status                                    | Blue (`4`)   |
-| `CONFIG_RGBLED_WIDGET_CONN_COLOR_ADVERTISING`  | Color for advertising BLE connection status                                  | Yellow (`3`) |
-| `CONFIG_RGBLED_WIDGET_CONN_COLOR_DISCONNECTED` | Color for disconnected BLE connection status                                 | Red (`1`)    |
-| `CONFIG_RGBLED_WIDGET_SHOW_LAYER_CHANGE`       | Indicate highest active layer on each layer change with a sequence of blinks | `n`          |
-| `CONFIG_RGBLED_WIDGET_LAYER_BLINK_MS`          | Blink and wait duration for layer indicator                                  | 100          |
-| `CONFIG_RGBLED_WIDGET_LAYER_COLOR`             | Color to use for layer indicator                                             | Cyan (`6`)   |
-| `CONFIG_RGBLED_WIDGET_LAYER_DEBOUNCE_MS`       | Wait duration after a layer change before showing the highest active layer   | 100          |
+| Name                                           | Description                                                                  | Default       |
+| ---------------------------------------------- | ---------------------------------------------------------------------------- | ------------- |
+| `CONFIG_RGBLED_WIDGET_INTERVAL_MS`             | Minimum wait duration between two blinks in ms                               | 500           |
+| `CONFIG_RGBLED_WIDGET_BATTERY_BLINK_MS`        | Duration of battery level blink in ms                                        | 2000          |
+| `CONFIG_RGBLED_WIDGET_BATTERY_LEVEL_HIGH`      | High battery level percentage                                                | 80            |
+| `CONFIG_RGBLED_WIDGET_BATTERY_LEVEL_LOW`       | Low battery level percentage                                                 | 20            |
+| `CONFIG_RGBLED_WIDGET_BATTERY_LEVEL_CRITICAL`  | Critical battery level percentage, blink periodically if under               | 5             |
+| `CONFIG_RGBLED_WIDGET_BATTERY_COLOR_HIGH`      | Color for high battery level (above `LEVEL_HIGH`)                            | Green (`2`)   |
+| `CONFIG_RGBLED_WIDGET_BATTERY_COLOR_MEDIUM`    | Color for medium battery level (between `LEVEL_LOW` and `LEVEL_HIGH`)        | Yellow (`3`)  |
+| `CONFIG_RGBLED_WIDGET_BATTERY_COLOR_LOW`       | Color for low battery level (below `LEVEL_LOW`)                              | Red (`1`)     |
+| `CONFIG_RGBLED_WIDGET_BATTERY_COLOR_CRITICAL`  | Color for critical battery level (below `LEVEL_CRITICAL`)                    | Red (`1`)     |
+| `CONFIG_RGBLED_WIDGET_CONN_BLINK_MS`           | Duration of BLE connection status blink in ms                                | 1000          |
+| `CONFIG_RGBLED_WIDGET_CONN_COLOR_CONNECTED`    | Color for connected BLE connection status                                    | Blue (`4`)    |
+| `CONFIG_RGBLED_WIDGET_CONN_COLOR_ADVERTISING`  | Color for advertising BLE connection status                                  | Yellow (`3`)  |
+| `CONFIG_RGBLED_WIDGET_CONN_COLOR_DISCONNECTED` | Color for disconnected BLE connection status                                 | Red (`1`)     |
+| `CONFIG_RGBLED_WIDGET_SHOW_LAYER_CHANGE`       | Indicate highest active layer on each layer change with a sequence of blinks | `n`           |
+| `CONFIG_RGBLED_WIDGET_LAYER_BLINK_MS`          | Blink and wait duration for layer indicator                                  | 100           |
+| `CONFIG_RGBLED_WIDGET_LAYER_COLOR`             | Color to use for layer indicator                                             | Cyan (`6`)    |
+| `CONFIG_RGBLED_WIDGET_LAYER_DEBOUNCE_MS`       | Wait duration after a layer change before showing the highest active layer   | 100           |
+| `CONFIG_RGBLED_WIDGET_SHOW_LAYER_COLORS`       | Indicate highest active layer with a constant configurable color per layer   | `n`           |
+| `CONFIG_RGBLED_WIDGET_LAYER_0_COLOR`           | Color to use for the base layer                                              | Black (`0`)   |
+| `CONFIG_RGBLED_WIDGET_LAYER_1_COLOR`           | Color to use for layer 1                                                     | Red (`1`)     |
+| `CONFIG_RGBLED_WIDGET_LAYER_2_COLOR`           | Color to use for layer 2                                                     | Green (`2`)   |
+| `CONFIG_RGBLED_WIDGET_LAYER_3_COLOR`           | Color to use for layer 3                                                     | Yellow (`3`)  |
+| `CONFIG_RGBLED_WIDGET_LAYER_4_COLOR`           | Color to use for layer 4                                                     | Blue (`4`)    |
+| `CONFIG_RGBLED_WIDGET_LAYER_5_COLOR`           | Color to use for layer 5                                                     | Magenta (`5`) |
+| `CONFIG_RGBLED_WIDGET_LAYER_6_COLOR`           | Color to use for layer 6                                                     | Cyan (`6`)    |
+| `CONFIG_RGBLED_WIDGET_LAYER_7_COLOR`           | Color to use for layer 7                                                     | White (`7`)   |
+| `CONFIG_RGBLED_WIDGET_LAYER_xx_COLOR`          | Color to use for layer xx (change xx to the layer number to change)          | Black (`0`)   |
 
 Color settings use the following integer values:
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Currently the widget does the following:
 - Blink 🔵 for connected, 🟡 for open (advertising), 🔴 for disconnected profiles on every BT profile switch (on central side for splits)
 - Blink 🔵 for connected, 🔴 for disconnected on peripheral side of splits
 
-In addition, there are two ways (each off by default) to indicate the layer:
+In addition, if desired you can pick one of the following methods (off by default) to indicate the layer:
 
 - enable `CONFIG_RGBLED_WIDGET_SHOW_LAYER_CHANGE` to show the highest active layer on every layer activation
   using a sequence of N cyan color blinks, where N is the zero-based index of the layer.
-- enable `CONFIG_RGBLED_WIDGET_SHOW_LAYER_COLORS` to assign each layer its own color, which will remain on while that layer is active.
+- or enable `CONFIG_RGBLED_WIDGET_SHOW_LAYER_COLORS` to assign each layer its own color, which will remain on while that layer is active.
 
 In addition, there are keymap behaviors you can use to show the status on demand, see [below](#showing-status-on-demand).
 

--- a/boards/shields/rgbled_adapter/README.md
+++ b/boards/shields/rgbled_adapter/README.md
@@ -4,13 +4,15 @@ This is a shield definition that defines the necessary aliases to use the
 RGB LED widget for certain boards, and automatically enables that feature.
 
 Boards currently supported are:
+
 - Xiao BLE (`seeeduino_xiao_ble`)
 - nRF52840 M.2 Module (`nrf52840_m2`)
 - Xiao RP2040 (`seeeduino_xiao_rp2040`[^1])
 
-Please see the [module README](/README.md) on general usage instructions, or
+Please see the [module README](../../../README.md) on general usage instructions, or
 to add support to a custom board/shield.
 
-[^1]: By default it doesn't do anything for RP2040 since there is no battery
-or BLE support for it. But you can extend the code in [`leds.c`](/leds.c) to
-listen to and display other events like sent keycodes.
+[^1]:
+    By default it doesn't do anything for RP2040 since there is no battery
+    or BLE support for it. But you can enable one of `CONFIG_RGBLED_WIDGET_SHOW_LAYER`
+    or `CONFIG_RGBLED_WIDGET_SHOW_LAYER_COLORS` to indicate the layer.

--- a/include/zmk_rgbled_widget/widget.h
+++ b/include/zmk_rgbled_widget/widget.h
@@ -2,6 +2,10 @@
     (IS_ENABLED(CONFIG_RGBLED_WIDGET_SHOW_LAYER_CHANGE)) &&                                        \
         (!IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL))
 
+#define SHOW_LAYER_COLORS                                                                          \
+    (IS_ENABLED(CONFIG_RGBLED_WIDGET_SHOW_LAYER_COLORS)) &&                                        \
+        (!IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL))
+
 #if IS_ENABLED(CONFIG_ZMK_BATTERY_REPORTING)
 void indicate_battery(void);
 #endif

--- a/src/widget.c
+++ b/src/widget.c
@@ -302,7 +302,7 @@ extern void led_process_thread(void *d0, void *d1, void *d2) {
             set_rgb_leds(blink.color, 0);
             k_sleep(K_MSEC(blink.duration_ms));
             set_rgb_leds(0, current_color);
-        else {
+        } else {
             set_rgb_leds(blink_color, current_color);
         }
 

--- a/src/widget.c
+++ b/src/widget.c
@@ -303,7 +303,7 @@ extern void led_process_thread(void *d0, void *d1, void *d2) {
             k_sleep(K_MSEC(blink.duration_ms));
             set_rgb_leds(0, current_color);
         } else {
-            set_rgb_leds(blink_color, current_color);
+            set_rgb_leds(blink.color, current_color);
         }
 
         // wait interval before processing another blink

--- a/src/widget.c
+++ b/src/widget.c
@@ -192,8 +192,8 @@ void update_layer_color(void) {
 
     if (led_current_layer_color != layer_color_idx[index]) {
         led_current_layer_color = layer_color_idx[index];
-        static const struct blink_item color = {.duration_ms = 5, .color = current_layer_color};
-        LOG_INF("Setting layer color to %s for layer %d", color_names[current_layer_color], index);
+        static const struct blink_item color = {.duration_ms = 5, .color = led_current_layer_color};
+        LOG_INF("Setting layer color to %s for layer %d", color_names[led_current_layer_color], index);
         k_msg_put(&led_msgq, &color, K_NO_WAIT);
     }
 }

--- a/src/widget.c
+++ b/src/widget.c
@@ -282,13 +282,14 @@ extern void led_process_thread(void *d0, void *d1, void *d2) {
         LOG_DBG("Got a blink item from msgq, color %d, duration %d", blink.color,
                 blink.duration_ms);
 
+        // turn appropriate LEDs on
         if (blink.color == current_color && current_color != 0) {
             set_rgb_leds(current_color, 0);
             k_sleep(K_MSEC(blink.duration_ms));
+            set_rgb_leds(0, blink.color);
+        } else {
+            set_rgb_leds(current_color, blink.color);
         }
-
-        // turn appropriate LEDs on
-        set_rgb_leds(current_color, blink.color);
 
         // wait for blink duration
         k_sleep(K_MSEC(blink.duration_ms));

--- a/src/widget.c
+++ b/src/widget.c
@@ -191,8 +191,8 @@ void update_layer_color(void) {
     uint8_t index = zmk_keymap_highest_layer_active();
 
     if (led_current_layer_color != layer_color_idx[index]) {
+        static const struct blink_item color = {.duration_ms = 5, .color = layer_color_idx[index]};
         led_current_layer_color = layer_color_idx[index];
-        static const struct blink_item color = {.duration_ms = 5, .color = led_current_layer_color};
         LOG_INF("Setting layer color to %s for layer %d", color_names[led_current_layer_color], index);
         k_msg_put(&led_msgq, &color, K_NO_WAIT);
     }

--- a/src/widget.c
+++ b/src/widget.c
@@ -289,7 +289,6 @@ extern void led_process_thread(void *d0, void *d1, void *d2) {
 
         // turn appropriate LEDs on
         set_rgb_leds(current_color, blink.color);
-        blink_color = blink.color;
 
         // wait for blink duration
         k_sleep(K_MSEC(blink.duration_ms));

--- a/src/widget.c
+++ b/src/widget.c
@@ -192,7 +192,7 @@ void update_layer_color(void) {
 
     if (led_current_layer_color != layer_color_idx[index]) {
         led_current_layer_color = layer_color_idx[index];
-        struct blink_item color = {.duration_ms = 5, .color = led_current_layer_color};
+        struct blink_item color = {.duration_ms = 5, .color = led_current_layer_color, .sleep_ms = 5};
         LOG_INF("Setting layer color to %s for layer %d", color_names[led_current_layer_color], index);
         k_msgq_put(&led_msgq, &color, K_NO_WAIT);
     }

--- a/src/widget.c
+++ b/src/widget.c
@@ -301,7 +301,7 @@ extern void led_process_thread(void *d0, void *d1, void *d2) {
         // turn appropriate LEDs off
         if (blink.color == current_color && current_color != 0) {
             set_rgb_leds(blink.color, 0);
-            k_sleep(K_MSEC(blink.duration_ms));
+            k_sleep(K_MSEC(CONFIG_RGBLED_WIDGET_INTERVAL_MS));
             set_rgb_leds(0, current_color);
         } else {
             set_rgb_leds(blink.color, current_color);

--- a/src/widget.c
+++ b/src/widget.c
@@ -187,13 +187,7 @@ ZMK_SUBSCRIPTION(led_battery_listener, zmk_battery_state_changed);
 #if SHOW_LAYER_COLORS
 uint8_t led_current_layer_color = 0;
 
-static int led_layer_color_listener_cb(const zmk_event_t *eh) {
-    ARG_UNUSED(eh);
-
-    if (!initialized) {
-      return 0;
-    }
-
+void update_layer_color(void) {
     uint8_t index = zmk_keymap_highest_layer_active();
 
     if (led_current_layer_color != layer_color_idx[index]) {
@@ -202,6 +196,16 @@ static int led_layer_color_listener_cb(const zmk_event_t *eh) {
         LOG_INF("Setting layer color to %s for layer %d", color_names[current_layer_color], index);
         k_msg_put(&led_msgq, &color, K_NO_WAIT);
     }
+}
+
+static int led_layer_color_listener_cb(const zmk_event_t *eh) {
+    ARG_UNUSED(eh);
+
+    if (!initialized) {
+      return 0;
+    }
+
+    update_layer_color();
 
     return 0;
 }
@@ -326,6 +330,11 @@ extern void led_init_thread(void *d0, void *d1, void *d2) {
     LOG_INF("Indicating initial connectivity status");
     indicate_connectivity();
 #endif // IS_ENABLED(CONFIG_ZMK_BLE)
+
+#if SHOW_LAYER_COLORS
+    LOG_INF("Setting initial layer color");
+    update_layer_color();
+#endif // SHOW_LAYER_COLORS
 
     initialized = true;
     LOG_INF("Finished initializing LED widget");

--- a/src/widget.c
+++ b/src/widget.c
@@ -292,6 +292,7 @@ extern void led_process_thread(void *d0, void *d1, void *d2) {
             previous_color = led_current_color;
             separation = blink.color == led_current_color && blink.color > 0;
 
+            // Blink the leds, using a separation blink if necessary
             if (separation) {
                 set_rgb_leds(0, CONFIG_RGBLED_WIDGET_INTERVAL_MS);
             }
@@ -299,12 +300,10 @@ extern void led_process_thread(void *d0, void *d1, void *d2) {
             if (separation) {
                 set_rgb_leds(0, CONFIG_RGBLED_WIDGET_INTERVAL_MS);
             }
-            set_rgb_leds(previous_color, blink.sleep_ms);
-
             // wait interval before processing another blink
-            if (blink.sleep_ms == 0) {
-                k_sleep(K_MSEC(CONFIG_RGBLED_WIDGET_INTERVAL_MS));
-            }
+            set_rgb_leds(previous_color, blink.sleep_ms > 0 ? blink.sleep_ms :
+                         CONFIG_RGBLED_WIDGET_INTERVAL_MS);
+
         } else {
             LOG_DBG("Got a layer color item from msgq, color %d", blink.color);
             set_rgb_leds(blink.color, 0);

--- a/src/widget.c
+++ b/src/widget.c
@@ -251,7 +251,7 @@ ZMK_SUBSCRIPTION(led_layer_listener, zmk_layer_state_changed);
 static void set_rgb_leds(uint8_t from_color, uint8_t to_color) {
     for (uint8_t pos = 0; pos < 3; pos++) {
         uint8_t bit = BIT(pos);
-        if (bit & from_color != bit & to_color) {
+        if ((bit & from_color) != (bit & to_color)) {
             // bits are different, so we need to change one
             if (bit & to_color) {
                 led_on(led_dev, rgb_idx[pos]);

--- a/src/widget.c
+++ b/src/widget.c
@@ -201,12 +201,9 @@ void update_layer_color(void) {
 static int led_layer_color_listener_cb(const zmk_event_t *eh) {
     ARG_UNUSED(eh);
 
-    if (!initialized) {
-      return 0;
+    if (initialized) {
+        update_layer_color();
     }
-
-    update_layer_color();
-
     return 0;
 }
 

--- a/src/widget.c
+++ b/src/widget.c
@@ -285,7 +285,7 @@ extern void led_process_thread(void *d0, void *d1, void *d2) {
         // turn appropriate LEDs on
         if (blink.color == current_color && current_color != 0) {
             set_rgb_leds(current_color, 0);
-            k_sleep(K_MSEC(blink.duration_ms));
+            k_sleep(K_MSEC(CONFIG_RGBLED_WIDGET_INTERVAL_MS));
             set_rgb_leds(0, blink.color);
         } else {
             set_rgb_leds(current_color, blink.color);

--- a/src/widget.c
+++ b/src/widget.c
@@ -40,7 +40,7 @@ static const char *color_names[] = {"black", "red",     "green", "yellow",
                                     "blue",  "magenta", "cyan",  "white"};
 
 #if SHOW_LAYER_COLORS
-static const uint8_t *layer_color_idx[] = {
+static const uint8_t layer_color_idx[] = {
   CONFIG_RGBLED_WIDGET_LAYER_0_COLOR, CONFIG_RGBLED_WIDGET_LAYER_1_COLOR,
   CONFIG_RGBLED_WIDGET_LAYER_2_COLOR, CONFIG_RGBLED_WIDGET_LAYER_3_COLOR,
   CONFIG_RGBLED_WIDGET_LAYER_4_COLOR, CONFIG_RGBLED_WIDGET_LAYER_5_COLOR,

--- a/src/widget.c
+++ b/src/widget.c
@@ -191,8 +191,8 @@ void update_layer_color(void) {
     uint8_t index = zmk_keymap_highest_layer_active();
 
     if (led_current_layer_color != layer_color_idx[index]) {
-        static const struct blink_item color = {.duration_ms = 5, .color = layer_color_idx[index]};
         led_current_layer_color = layer_color_idx[index];
+        struct blink_item color = {.duration_ms = 5, .color = led_current_layer_color};
         LOG_INF("Setting layer color to %s for layer %d", color_names[led_current_layer_color], index);
         k_msg_put(&led_msgq, &color, K_NO_WAIT);
     }

--- a/src/widget.c
+++ b/src/widget.c
@@ -194,7 +194,7 @@ void update_layer_color(void) {
         led_current_layer_color = layer_color_idx[index];
         struct blink_item color = {.duration_ms = 5, .color = led_current_layer_color};
         LOG_INF("Setting layer color to %s for layer %d", color_names[led_current_layer_color], index);
-        k_msg_put(&led_msgq, &color, K_NO_WAIT);
+        k_msgq_put(&led_msgq, &color, K_NO_WAIT);
     }
 }
 

--- a/src/widget.c
+++ b/src/widget.c
@@ -29,6 +29,9 @@ BUILD_ASSERT(DT_NODE_EXISTS(DT_ALIAS(led_green)),
 BUILD_ASSERT(DT_NODE_EXISTS(DT_ALIAS(led_blue)),
              "An alias for a blue LED is not found for RGBLED_WIDGET");
 
+BUILD_ASSERT(!(SHOW_LAYER_CHANGE && SHOW_LAYER_COLORS),
+             "CONFIG_RGBLED_WIDGET_SHOW_LAYER_CHANGE and CONFIG_RGBLED_WIDGET_SHOW_LAYER_COLORS are mutually exclusive");
+
 // GPIO-based LED device and indices of red/green/blue LEDs inside its DT node
 static const struct device *led_dev = DEVICE_DT_GET(LED_GPIO_NODE_ID);
 static const uint8_t rgb_idx[] = {DT_NODE_CHILD_IDX(DT_ALIAS(led_red)),


### PR DESCRIPTION
I installed the rgbled widget on a xiao rp2040, and was a bit disappointed that ... nothing happened.

So I thought to fork the repo and make a rp2040-specific version that lets you define a color for each layer. But then as I was developing it, I realized there's not really a reason this couldn't be part of the original repo, since it's only active while a layer is active, and the rest of the time it's off.

But I'm getting ahead of myself. Summary of feature:

- by default, nothing, so that this doesn't impact anyone currently using the module.
- if enabled, turns on the light when a layer is active.
- the color for each layer can be configured.
- when a layer is set to black (which is the default for the base layer) the led is off, and the behavior is the same as without this option.

Up to you if you want to accept this pull request, if not, I can maintain this fork.