### PR TITLE
Add support for nRF52840 MDK USB Dongle

### DIFF
--- a/boards/shields/rgbled_adapter/README.md
+++ b/boards/shields/rgbled_adapter/README.md
@@ -7,6 +7,7 @@ Boards currently supported are:
 
 - Xiao BLE (`seeeduino_xiao_ble`)
 - nRF52840 M.2 Module (`nrf52840_m2`)
+- nRF52840 MDK USB Dongle (`nrf52840_mdk_usb_dongle`)
 - Xiao RP2040 (`seeeduino_xiao_rp2040`[^1])
 
 Please see the [module README](../../../README.md) on general usage instructions, or

--- a/boards/shields/rgbled_adapter/boards/nrf52840_mdk_usb_dongle.overlay
+++ b/boards/shields/rgbled_adapter/boards/nrf52840_mdk_usb_dongle.overlay
@@ -1,0 +1,11 @@
+/ {
+    aliases {
+        led-red = &led0_red;
+        led-green = &led0_green;
+        led-blue = &led0_blue;
+    };
+
+    leds {
+        status = "okay";
+    };
+};


### PR DESCRIPTION
Hey,

this adds support for the [nRF52840 MDK USB Dongle](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/hardware/#button-and-leds) which is [supported by Zephyr](https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/makerdiary/nrf52840_mdk_usb_dongle/nrf52840_mdk_usb_dongle.dts)

I have tested this via my fork, adding `rgbled_adapter` as additional shield to my dongle in the `build.yaml`, and it seems to be working.

