### PR TITLE
fix uint16_t overflow in blink duration fields

### DIFF
--- a/src/widget.c
+++ b/src/widget.c
@@ -82,8 +82,8 @@ static const uint8_t layer_color_idx[] = {
 // a blink work item as specified by the color and duration
 struct blink_item {
     uint8_t color;
-    uint16_t duration_ms;
-    uint16_t sleep_ms;
+    uint32_t duration_ms;
+    uint32_t sleep_ms;
 };
 
 // flag to indicate whether the initial boot up sequence is complete
@@ -93,7 +93,7 @@ static bool initialized = false;
 uint8_t led_current_color = 0;
 
 // low-level method to control the LED
-static void set_rgb_leds(uint8_t color, uint16_t duration_ms) {
+static void set_rgb_leds(uint8_t color, uint32_t duration_ms) {
     for (uint8_t pos = 0; pos < 3; pos++) {
         uint8_t bit = BIT(pos);
         if ((bit & led_current_color) != (bit & color)) {


### PR DESCRIPTION
## Summary
- `duration_ms` and `sleep_ms` in `blink_item` and the `set_rgb_leds` parameter are `uint16_t`, silently truncating any value over 65535ms (~65s)
- The Kconfig defines these as `int` (32-bit), so users can set values like `CONFIG_RGBLED_WIDGET_CONN_BLINK_MS=36000000` without any build warning, but the actual duration wraps to `36000000 % 65536 = 20736ms`
- Changed all three to `uint32_t` to match the Kconfig range

## Context
Discovered while using a long `CONN_BLINK_MS` as a persistent power indicator on a split peripheral. The LED would turn off after ~20 seconds instead of the configured 10 hours.